### PR TITLE
Add `node_modules` to the archive exclude list in `composer.json`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
   },
   "archive": {
     "exclude": [
-      "!/build"
+      "!/build",
+      "node_modules"
     ]
   }
 }


### PR DESCRIPTION
This will prevent `node_modules` from going into the archive.

To test, please run `npm run build` and ensure the built zip doesn't have `node_modules`.