### PR TITLE
Add validation error to interact with data store

### DIFF
--- a/assets/js/checkout-newsletter-subscription-block/block.js
+++ b/assets/js/checkout-newsletter-subscription-block/block.js
@@ -4,6 +4,7 @@
 import { useEffect, useState } from '@wordpress/element';
 import { CheckboxControl } from '@woocommerce/blocks-checkout';
 import { getSetting } from '@woocommerce/settings';
+import { useSelect, useDispatch } from '@wordpress/data';
 
 const { optinDefaultText } = getSetting( 'newsletter-test_data', '' );
 
@@ -11,18 +12,57 @@ const Block = ( { children, checkoutExtensionData } ) => {
 	const [ checked, setChecked ] = useState( false );
 	const { setExtensionData } = checkoutExtensionData;
 
+	const { setValidationErrors, clearValidationError } = useDispatch(
+		'wc/store/validation'
+	);
+
 	useEffect( () => {
 		setExtensionData( 'newsletter-test', 'optin', checked );
-	}, [ checked, setExtensionData ] );
+		if ( ! checked ) {
+			setValidationErrors( {
+				'newsletter-test': {
+					message: 'Please tick the box',
+					hidden: false,
+				},
+			} );
+			return;
+		}
+		clearValidationError( 'newsletter-test' );
+	}, [
+		clearValidationError,
+		setValidationErrors,
+		checked,
+		setExtensionData,
+	] );
+
+	const { getValidationError } = useSelect( ( select ) => {
+		const store = select( 'wc/store/validation' );
+		return {
+			getValidationError: store.getValidationError(),
+		};
+	} );
+
+	const errorMessage = getValidationError( 'newsletter-test' )?.message;
 
 	return (
-		<CheckboxControl
-			id="subscribe-to-newsletter"
-			checked={ checked }
-			onChange={ setChecked }
-		>
-			{ children || optinDefaultText }
-		</CheckboxControl>
+		<>
+			<CheckboxControl
+				id="subscribe-to-newsletter"
+				checked={ checked }
+				onChange={ setChecked }
+			>
+				{ children || optinDefaultText }
+			</CheckboxControl>
+
+			{ errorMessage && (
+				<div>
+					<span role="img" aria-label="Warning emoji">
+						⚠️
+					</span>
+					{ errorMessage }
+				</div>
+			) }
+		</>
 	);
 };
 

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
   },
   "archive": {
     "exclude": [
-      "!/build"
+      "!/build",
+      "node_modules"
     ]
   }
 }


### PR DESCRIPTION
This PR adds a validation error that shows up when the box is unticked. This is just for demonstration purposes of how to use the validation data store.

To test:

1. In WC Blocks, Check out `fix/wpdata-validation` (or if this has been merged, `trunk` will work)
2. Add the newsletter signup block to your checkout block.
3. Add items to your cart then go to the Checkout Block on the front-end.
4. Tick the box and see the error message disappears, untick the box and see the error message.